### PR TITLE
Process client replies with the help of the ORM system

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,2 +1,3 @@
-flask==1.0.2
-pymongo>=3.9.0
+flask>=1.0.2
+pymongo>=3.4.0
+mongoengine==0.23.1


### PR DESCRIPTION
Closes #11
(Actually only addresses the validation part, since consensus should be applied after the collection of the data)

We're now using mongoengine's connection scheme and ORM to process answers to labeling problems POSTed to the server as JSON forms, which must follow the following schema:
```jsonc
{
  "dataset_id": "string",  // received by the client as `problem.dataset._id`
  "instance_id": "string", // received by the client as `problem.instance._id`
  "label": "string"        // answer, must be valid according to the dataset format
}
```

HTTP status code 201 is sent on success. Error 400 in case the received answer doesn't pass validation.
It could also be the case that some Python exception crops up, in which case we'll give the client a generic 500 error code.

**NOTE:** `'GRID'` type problems need to be handled specially when updating the answers in the DB, since that is not yet implemented it doesn't pass validation and gives a 501 status code.