### PR TITLE
formatted, refactored, and divided the ORM classes up into files for Single Responsibility Principle reason

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,5 +58,5 @@ client:
 	sudo docker exec -it client-crowd-sourced /bin/bash
 
 precommit:
-	black server && flake8 server
+	flake8 server && black server
 	

--- a/server/app.py
+++ b/server/app.py
@@ -2,31 +2,14 @@
 
 from flask import Flask, render_template, jsonify, request, Response
 from werkzeug.exceptions import HTTPException
-from mongoengine import (
-    connect,
-    Document,
-    StringField,
-    ListField,
-    ReferenceField,
-    DictField,
-)
+from mongoengine import connect
+
+# Local imports
+from .models.instance import Instance
+from .models.dataset import Dataset
 
 app = Flask(__name__)
 connect(host="mongodb://root:SGG@mongo:27017/demo?authSource=admin")
-
-
-class Dataset(Document):
-    name = StringField(primary_key=True)
-    content_type = StringField(required=True, choices=["IMAGE", "TEXT"])
-    message = StringField(required=True)
-    label_type = StringField(required=True, choices=["CLASS", "LABEL", "GRID"])
-    options = ListField(StringField())
-
-
-class Instance(Document):
-    dataset = ReferenceField(Dataset, required=True)
-    url = StringField(required=True, unique_with="dataset")
-    labels = DictField()  # label -> frequency
 
 
 @app.route("/", methods=["GET", "POST"])
@@ -54,7 +37,7 @@ def index():
 
         instance = Instance.objects(dataset=dataset_id, url=instance_id).get()
         labels = instance["labels"]
-        frequency = labels[label] + 1 if label in labels else 0
+        frequency = labels[label] + 1 if label in labels else 1
         labels[label] = frequency
         instance.save()
 

--- a/server/models/dataset.py
+++ b/server/models/dataset.py
@@ -1,0 +1,13 @@
+from mongoengine import (
+    Document,
+    StringField,
+    ListField,
+)
+
+
+class Dataset(Document):
+    name = StringField(primary_key=True)
+    content_type = StringField(required=True, choices=["IMAGE", "TEXT"])
+    message = StringField(required=True)
+    label_type = StringField(required=True, choices=["CLASS", "LABEL", "GRID"])
+    options = ListField(StringField())

--- a/server/models/image.py
+++ b/server/models/image.py
@@ -1,0 +1,13 @@
+from mongoengine import (
+    Document,
+    StringField,
+    ReferenceField,
+    DictField,
+)
+from .dataset import Dataset
+
+
+class Image(Document):
+    dataset = ReferenceField(Dataset, required=True)
+    url = StringField(required=True, unique_with="dataset")
+    labels = DictField(StringField)

--- a/server/models/instance.py
+++ b/server/models/instance.py
@@ -1,0 +1,15 @@
+from mongoengine import (
+    Document,
+    StringField,
+    ReferenceField,
+    DictField,
+)
+from .dataset import Dataset
+
+
+class Instance(Document):
+    dataset = ReferenceField(Dataset, required=True)
+    url = StringField(required=True, unique_with="dataset")
+    labels = DictField()  # label -> frequency
+    text = StringField(required=True)
+    text_url = StringField(required=True)

--- a/server/models/tweet.py
+++ b/server/models/tweet.py
@@ -1,0 +1,9 @@
+from mongoengine import Document, StringField, ReferenceField, DictField, IntField
+from .dataset import Dataset
+
+
+class Tweet(Document):
+    _id = IntField(primary_key=True)
+    dataset = ReferenceField(Dataset, required=True)
+    tweet = StringField(required=True)  # , unique_with="dataset")
+    labels = DictField(StringField)


### PR DESCRIPTION
As the title states. Created a folder called models, and write the classes in the files as the same name as them. Needed a quick refactor, and introduced some schema changes as well by @fissoreg he mentioned on the GitHub issue, #6 